### PR TITLE
Fix results indicator (1) on zero results and (2) on less than 20 results

### DIFF
--- a/src/main/resources/assets/js/bing.js
+++ b/src/main/resources/assets/js/bing.js
@@ -197,7 +197,12 @@ $('document').ready(function () {
         var count = parseInt($("[name=count]").val(), 10);
 
         // Only update the text here
-        $(".resultInfo").html("Results " + (offset + 1) + " to " + (offset + count) + " of about " + results.webPages.totalEstimatedMatches + ".");
+        if(!results.webPages){
+            $(".resultInfo").html("No results.");
+        } else {
+            var maxPerPage = Math.min((offset + count), results.webPages.totalEstimatedMatches);
+            $(".resultInfo").html("Results " + (offset + 1) + " to " + maxPerPage + " of about " + results.webPages.totalEstimatedMatches + ".");
+        }
         console.log("Finished updating paging info");
     }
 });


### PR DESCRIPTION
(1) On zero results a the results.webPages attribute does not exist so the code fails, not updating results at all.

(2) On less than 20 results you get Results 1 to 20 of about 13. Fixed such that the upper bound is never more than the estimated number of results.